### PR TITLE
Update NOAA link

### DIFF
--- a/practical-applications.rst
+++ b/practical-applications.rst
@@ -8,8 +8,9 @@ Tuning in NOAA stations
 
 There are a few quick ways to tell if your setup is working properly. 
 Nothing beats getting some useful weather data while you're at it.  To get
-started, head over to http://www.nws.noaa.gov/nwr/coverage/station_listing.html
-and find your local weather station frequency.
+started, head over to https://www.weather.gov/nwr/ for information on the service
+and the common frequencies used.  The "Coverage" tab can be used to drill down to
+a local station frequency.
 
 To get started, find your "Modulation Selector" in the upper
 left side of the display.  NOAA broadcasts in Narrow Band FM or NBFM, so go


### PR DESCRIPTION
The current NOAA station listing URL 404s.  This PR updates the link to point to the general NOAA NWR landing page, with a tip to drill into the coverage map.  I did not link directly to the coverage map as I felt the NWR page is a batter landing page for those unfamiliar with the service and because I believe the NWR link will be less brittle long term.